### PR TITLE
query: default to empty map instead of empty list

### DIFF
--- a/lib/cqex/query.ex
+++ b/lib/cqex/query.ex
@@ -16,7 +16,7 @@ defmodule CQEx.Query do
   @default_consistency 1
 
   defstruct statement: "",
-    values: [],
+    values: %{},
     reusable: nil,
     named: false,
     page_size: 100,
@@ -109,18 +109,18 @@ defmodule CQEx.Query do
   end
 
   def put(q = %CQEx.Query{ values: values }, key, value) do
-    values = values || []
+    values = values || %{}
     %{ q | values: Map.put(values, key, value) }
   end
   def get(%CQEx.Query{ values: values }, key, default \\ nil) do
-    Map.get((values || []), key, default)
+    Map.get((values || %{}), key, default)
   end
   def delete(q = %CQEx.Query{ values: values }, key) do
-    values = values || []
+    values = values || %{}
     %{ q | values: Map.delete(values, key) }
   end
   def merge(q = %CQEx.Query{ values: values }, other) do
-    values = values || []
+    values = values || %{}
     %{ q | values: Map.merge(values, other) }
   end
 


### PR DESCRIPTION
Map functions do not accept an empty list and default values were not updated when transitioning from `Dict` to `Map`.

The current master gives this error:
```
➜  cqex git:(master) ✗ iex -S mix
Erlang/OTP 19 [erts-8.3] [source-d5c06c6] [64-bit] [smp:8:8] [async-threads:10] [hipe] [kernel-poll:false]

Interactive Elixir (1.4.4) - press Ctrl+C to exit (type h() ENTER for help)
iex(1)> CQEx.Query.new |> CQEx.Query.statement("SELECT * FROM table WHERE col=:some_value") |> CQEx.Query.put(:some_value, 42)
** (BadMapError) expected a map, got: []
    (stdlib) :maps.put(:some_value, 42, [])
      (cqex) lib/cqex/query.ex:113: CQEx.Query.put/3
```

This PR fixes this.